### PR TITLE
Improved save type detection

### DIFF
--- a/src/save/installer.event
+++ b/src/save/installer.event
@@ -310,3 +310,29 @@ WORD 0x203FE00+(06*2) //offset
 //WORD 0x203FE00+(07*2) //offset of times quickwarped
 
 #include "credits/credits.event"
+
+//improve save type detection on emulators, virtual console injectors, etc
+//none of this has an actual impact on the game itself
+PUSH
+	//game title and game code, to prevent automatic EEPROM save type selection for TMC
+	//this used to be more common, although I believe nowadays the string check method is used more often
+	//game title (GBAZELDA MC)
+	ORG $A0 // 3 words
+	WORD 0 0 0 // clear the previous game title
+	ORG $A0
+	String("MINISH RANDO");
+	//game code (BZMP)
+	ORG $AC // 1 word
+	String("TMCR");
+	//complement check (checksum), needs to be adjusted or the game won't boot on real hardware
+	ORG $BD
+	BYTE 0x82
+	
+	//EEPROM strings, often checked by external programs
+	//the strings must be at a word aligned offset, and must have a length multipled of word size
+	//here the original strings in the rom are replaced with equal length or smaller strings, padded with 0s
+	ORG $EF32CC
+	String("SRAM_F_V103"); BYTE 0
+	ORG $EF330C
+	String("SRAM_F_V103"); BYTE 0 0 0 0 0
+POP

--- a/src/save/installer.event
+++ b/src/save/installer.event
@@ -332,7 +332,7 @@ PUSH
 	//the strings must be at a word aligned offset, and must have a length multiple of word size
 	//here the original strings in the rom are replaced with equal length or smaller strings, padded with 0s
 	ORG $EF32CC
-	String("SRAM_F_V103"); BYTE 0
+	String("SRAM_V103"); BYTE 0 0 0
 	ORG $EF330C
 	String("SRAM_F_V103"); BYTE 0 0 0 0 0
 POP

--- a/src/save/installer.event
+++ b/src/save/installer.event
@@ -322,11 +322,12 @@ PUSH
 	ORG $A0
 	String("MINISH RANDO");
 	//game code (BZMP)
+	//apparently game codes starting with S can be detected as SRAM games, at least for open_agb_firm
 	ORG $AC // 1 word
-	String("TMCR");
+	String("SZMR");
 	//complement check (checksum), needs to be adjusted or the game won't boot on real hardware
 	ORG $BD
-	BYTE 0x82
+	BYTE 0x98
 	
 	//EEPROM strings, often checked by external programs
 	//the strings must be at a word aligned offset, and must have a length multiple of word size

--- a/src/save/installer.event
+++ b/src/save/installer.event
@@ -329,7 +329,7 @@ PUSH
 	BYTE 0x82
 	
 	//EEPROM strings, often checked by external programs
-	//the strings must be at a word aligned offset, and must have a length multipled of word size
+	//the strings must be at a word aligned offset, and must have a length multiple of word size
 	//here the original strings in the rom are replaced with equal length or smaller strings, padded with 0s
 	ORG $EF32CC
 	String("SRAM_F_V103"); BYTE 0


### PR DESCRIPTION
TMCR patches the game to use SRAM, which it then uses to keep track of a bunch of extra stuff (time played, enemy kills, when each item was found, etc.).

However, from time to time someone tries to play TMCR on an emulator, through VC injection or by using a flashcart that incorrectly detects the save type as EEPROM, which is TMC's original save type. I wrote this change for that, and I figured it could be added here as well.

The issue happens because the ROM is checked for strings containing the save type (from what I understand, these were inserted by the devkit back in the day, so it is pretty reliable) or because the game title or game code are used to check against some list of known save types for GBA titles.

These changes do away with the original game title, code and save type strings so that automatic detection cannot have a reason to select EEPROM. The save type strings are also replaced by SRAM ones, so that the new save type may be detected. The functionality of the game itself is not changed, although some emulators may display the new game title (MINISH RANDO) in the window title.

I checked the results with GBA Tool Advance, which now correctly detects the save type as SRAM, and a GBA VC injector for 3DS, which failed to detect a save type at all. Originally, both of these tools detected the save type as EEPROM, so I believe this is an improvement.
_edit: After the 2 strings change, the VC injector also detects the SRAM save type._

If you would like, the game title and game code can be adjusted, but if they are changed then the complement needs to be updated as well.

PS: I also tested with an EZ-Flash Omega, but it continues having the same issue: the save is updated too quickly for it to ever catch up. I think this could be fixed by having the changes only write to the save every so often (iirc it's just the playtime that gets saved every frame anyway?) but that's a different topic.